### PR TITLE
fix: make navbar sticky with top-0 inset

### DIFF
--- a/client/src/components/main/Navbar.tsx
+++ b/client/src/components/main/Navbar.tsx
@@ -18,8 +18,7 @@ export default function Navbar() {
 
   return (
     <>
-      <header className="sticky flex h-24 w-full flex-wrap items-center justify-center rounded-md border-b border-border/20 bg-background px-20 font-jersey10">
-        <Link
+      <header className="sticky top-0 z-50 flex h-24 w-full flex-wrap items-center justify-center rounded-md border-b border-border/20 bg-background px-20 font-jersey10">        <Link
           href="/"
           className="flex flex-none items-center gap-3 text-2xl md:mr-5"
         >


### PR DESCRIPTION
### Summary
This PR fixes the navbar not sticking to the top while scrolling.

### What was causing the issue
The `<header>` element used `position: sticky` (Tailwind class `sticky`) but did not include an inset value such as `top-0`. Without an inset, sticky positioning does not activate.

### What I changed
- Added `top-0` to enable sticky behavior
- Added `z-50` to ensure the navbar stays above page content

### Result
The navbar now remains fixed at the top while scrolling on all screen sizes.

Fixes #21
