### PR TITLE
Update dark-alt color value in globals.css

### DIFF
--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -7,7 +7,7 @@
     /* Figma Colours */
     --dark-1: 0 0% 0%;
     --dark-2: 236 64% 10%;
-    --dark-alt: 296 50% 11%;
+    --dark-alt: 260 52.38% 12.35%;
     --neutral-1: 235 64% 30%;
     --neutral-2: 235 64% 40%;
     --neutral-3: 235 64% 49%;


### PR DESCRIPTION
## Change Summary
Change the color for dark-alt in the globals.css file to a different colour that is being used instead

### Change Form

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests Unneccessary
- [ ] The change has documentation Unneccessary

## Other Information
