### PR TITLE
Add Member Serializer

### DIFF
--- a/server/game_dev/serializers.py
+++ b/server/game_dev/serializers.py
@@ -21,7 +21,6 @@ class MemberSerializer(serializers.ModelSerializer):
         model = Member
         fields = [
             "name",
-            "active",
             "profile_picture",
             "about",
             "pronouns"


### PR DESCRIPTION
## Change Summary
Add a serializer for the member model in serializers.py. The purpose of this is to allow fetching of member objects as part of the committee page (e.g putting the committee's info on the page as the committee's pk is a member object) without needing a full merge of the member page branch. 

### Change Form

- [ ] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [x] The change has documentation

## Other Information
