### PR TITLE
Issue 87 Game can be showcased multiple times

### DIFF
--- a/server/game_dev/models.py
+++ b/server/game_dev/models.py
@@ -69,7 +69,7 @@ class Game(models.Model):
 
 
 class GameShowcase(models.Model):
-    game = models.ForeignKey('Game', on_delete=models.CASCADE, related_name='game_showcases')
+    game = models.ForeignKey('Game', on_delete=models.CASCADE, related_name='game_showcases', unique=True)
     description = models.TextField()
 
     def __str__(self):


### PR DESCRIPTION
## Change Summary
**Adding a game showcase now throws an error in Django admin if game showcase for the same game already exists**

<img width="1470" height="765" alt="Screenshot 2026-02-07 at 1 15 13 pm" src="https://github.com/user-attachments/assets/8b985bbf-08cb-476f-9a89-b214687f797e" />

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation


# Related issue

- Resolve #87