### PR TITLE
Reworking how committee pronouns and names are arranged

### DIFF
--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -95,10 +95,8 @@ export default function AboutPage() {
                 </Link>
               )}
             </text>
-            <text className="inline-block bg-card px-2 py-1">
-              {committeeMember.pronouns === ""
-                ? "No Pronouns"
-                : committeeMember.pronouns}
+            <text className="inline-block bg-card px-2 py-1 empty:hidden">
+              {committeeMember.pronouns}
             </text>
           </p>
           <p className="inline-block bg-card px-2 py-1 text-primary">


### PR DESCRIPTION
## Change Summary
I'll try explain the problem:
Having average-sized names and pronouns on committee portraits fit how it looks on the figma, but with long enough names and pronouns, it starts to act weird:

<img width="200" height="233" alt="Screenshot 2026-02-18 213739" src="https://github.com/user-attachments/assets/bd1656fe-a4c5-4afa-9fc5-40bf687d2394" />

It's alright if the name is long enough, but it still feels weird to me at least as the background fills the full surrounding rectangle and so leaves unwanted empty space.

<img width="215" height="248" alt="Screenshot 2026-02-18 213624" src="https://github.com/user-attachments/assets/fe7d9ce5-f85b-4222-bd86-233224d41911" />

Changes present in this pr hopefully solve this by having the name and pronouns separate be inline-blocks, so each committee portrait will have the name and pronouns arranged to look like the figma if the length of text is small enough, otherwise the pronouns will go to the next line

<img width="185" height="235" alt="Screenshot 2026-02-18 213917" src="https://github.com/user-attachments/assets/bdcfc1a5-c86e-4828-89f2-727941de0be6" />

The name will wrap to the next line of it's container if long enough and still fill it's box, but I don't know if that's an issue in itself.
 
<img width="197" height="257" alt="image" src="https://github.com/user-attachments/assets/c432d498-cce5-4460-90e2-c340719eaea9" />

### Change Form

- [] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [x] The change has documentation

## Other Information

# Related issue

- Resolve #107