### PR TITLE
issue 118 - linked landing page buttons to game and art showcase respectively

### DIFF
--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -180,10 +180,10 @@ export default function Landing() {
             </div>
 
             <div className="flex flex-col items-end gap-4">
-              <Link href="/">
+              <Link href="/games">
                 <Button>See more games by our members</Button>
               </Link>
-              <Link href="/">
+              <Link href="/artwork">
                 <Button variant={"outline"}>
                   See other cool stuff our members have created
                 </Button>


### PR DESCRIPTION
## Change Summary
**replaced placeholder links for "See more games by our members" and "See other cool stuff our members have created" with game and art showcase links on landing page**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

# Related issue

- Resolve #118