### PR TITLE
Issue #145 deal with main background and navbar being the same colour

### DIFF
--- a/client/src/components/main/Navbar.tsx
+++ b/client/src/components/main/Navbar.tsx
@@ -25,7 +25,7 @@ export default function Navbar() {
 
   return (
     <>
-      <header className="sticky top-0 z-50 flex h-24 w-full items-center rounded-md border-b border-border/20 bg-background px-20 font-jersey10">
+      <header className="sticky top-0 z-50 flex h-24 w-full items-center border-b-2 border-border/20 border-b-primary bg-landingCard px-20 font-jersey10">
         <div className="flex flex-1 items-center">
           <Link
             href="/"


### PR DESCRIPTION
## Change Summary

This pr just has a few changes to improve the navbar's styling and to also fulfil the issue. Some of this may be subjective so feel free to request something else.

- Removed roundedness to the navbar border, this is to stay consistent with the sharp, non-rounded style of the website (we can discuss if you disagree)
- Added a width for the navbar's bottom border
- Changed the navbar's background colour from background to landingCard, which will contrast better with the pages and not blend in with the background like previously

This is what it looks like in contrast to the main background:
<img width="1126" height="224" alt="image" src="https://github.com/user-attachments/assets/35bdcbd2-ede6-4cf1-8429-198d6558db89" />

### Change Form

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [x] The change has documentation

# Related issue

- Resolve #145